### PR TITLE
Some additional work to get ARIES-1565 working

### DIFF
--- a/subsystem/subsystem-core/pom.xml
+++ b/subsystem/subsystem-core/pom.xml
@@ -53,7 +53,9 @@
         </aries.osgi.import>
         <aries.osgi.export.pkg />
         <aries.osgi.private.pkg>
-            org.apache.aries.subsystem.core.*
+            org.apache.aries.subsystem.core.*,
+            org.apache.aries.util.filesystem.impl,
+            org.apache.aries.util.internal
         </aries.osgi.private.pkg>
         <lastReleaseVersion>1.0.0</lastReleaseVersion>
         <aries.osgi.provide.capability>
@@ -76,7 +78,7 @@
         <dependency>
             <groupId>org.apache.aries</groupId>
             <artifactId>org.apache.aries.util</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.aries.application</groupId>

--- a/subsystem/subsystem-core/src/main/java/org/apache/aries/subsystem/core/internal/filesystem/UnpackingFileSystemImpl.java
+++ b/subsystem/subsystem-core/src/main/java/org/apache/aries/subsystem/core/internal/filesystem/UnpackingFileSystemImpl.java
@@ -91,11 +91,12 @@ public class UnpackingFileSystemImpl {
 		ZipEntry entry = zipInputStream.getNextEntry();
 		while (entry != null) {
 			String filePath = directoryLocation + File.separator + entry.getName();
+			File file = new File(filePath);
 			if (!entry.isDirectory()) {
-				extractFile(zipInputStream, filePath);
+				file.getParentFile().mkdirs();
+				extractFile(zipInputStream, file);
 			} else {
-				File dir = new File(filePath);
-				dir.mkdir();
+				file.mkdirs();
 			}
 			zipInputStream.closeEntry();
 			entry = zipInputStream.getNextEntry();
@@ -103,7 +104,7 @@ public class UnpackingFileSystemImpl {
 		zipInputStream.close();
 	}
 
-	private static void extractFile(ZipInputStream zipInputStream, String path) throws IOException {
+	private static void extractFile(ZipInputStream zipInputStream, File path) throws IOException {
 		BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(path));
 		byte[] bytesIn = new byte[BUFFER_SIZE];
 		int readByte = zipInputStream.read(bytesIn);

--- a/util/util-r42/src/main/java/org/apache/aries/util/filesystem/impl/ZipFileImpl.java
+++ b/util/util-r42/src/main/java/org/apache/aries/util/filesystem/impl/ZipFileImpl.java
@@ -197,7 +197,7 @@ public class ZipFileImpl implements IFile
   {
     URL result;
 
-    if(name.equals(zipPathToRoot))
+    if(name.equals(zipPathToRoot) || (entry == null && zipPathToRoot.equals(name+'/')))
       result = new URL(url);
     else {
 


### PR DESCRIPTION
Wouter, I have been reviewing your pull request for ARIES-1565.  It currently is not working because it uses internals from aries.util which are not exported.  This makes the aries.subsystem.core bundle unresolvable at runtime.  The error from pax exam are far from useful but they are being caused because the aries.subsystem.core bundle cannot resolve.  To hack around this I made all the util packages as package private to the aries.subsystem.core bundle.  This is not ideal, I probably would prefer we add some new API to util and move the unpacking stuff from aries.subsystem.core to aries.util bundle.

After I got past the resolution issue I ran into two more issues.  One was an issue in aries.util which I fixed in one commit.  The other was in the unpacking code which assumes directories are created before each zip entry file is extracted.  I added a fix to ensure the parent directory exists before extracting a zip file entry.  This is important for jar zips which have META-INF/MANIFEST.MF as the very first entry with no META-INF/ directory entry.

After this fixed I am still seeing some issues in org.apache.aries.subsystem.itests.defect.Aries1383Test where it is timing out.  I have not determined if this is caused by the changes in this pull request or not yet.  But I have run out of time to look at this for the week.  I thought it would be good to hand over what I did to you for a look.